### PR TITLE
Work on making the FUZIX build process work with latest gcc 9.2 from TI

### DIFF
--- a/Applications/V7/cmd/Makefile.msp430x
+++ b/Applications/V7/cmd/Makefile.msp430x
@@ -5,7 +5,7 @@ AR = msp430-elf-ar
 LINKER = msp430-elf-ld
 CFLAGS = -ffunction-sections -fdata-sections -funit-at-a-time -mhwmult=auto -mmcu=msp430fr5969 -Wall -Werror=implicit-function-declaration --short-enums -Os -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -fno-inline -fno-common -I../../../Library/include -g -c
 export PLATFORM
-LINKER_OPT = -L../../../Library/libs -g --gc-sections --relax -T ../../../Build/platforms/msp430fr5969.ld.out -lcmsp430x -L$(LIBGCCDIR) -lgcc
+LINKER_OPT = --undefined __mspabi_mpyi -lmul_f5 -L../../../Library/libs -g --gc-sections --relax -T ../../../Build/platforms/msp430fr5969.ld.out -lcmsp430x -L$(LIBGCCDIR) -lgcc
 # cpp -P msp430fr5969.ld -I../../Build/platforms > msp430fr5969.ld.out
 LIBGCCDIR = $(dir $(shell $(CC) -print-libgcc-file-name))
 CRT0 = ../../../Library/libs/crt0_msp430x.o

--- a/Applications/V7/cmd/sh/Makefile.msp430x
+++ b/Applications/V7/cmd/sh/Makefile.msp430x
@@ -1,9 +1,9 @@
 PLATFORM = msp430x
 CC = msp430-elf-gcc
 ASM = msp430-elf-as
-AR = msp430-elf-ar
+AR = msp430-elf-ar 
 LINKER = msp430-elf-ld
-CFLAGS = -ffunction-sections -fdata-sections -funit-at-a-time -mhwmult=auto -mmcu=msp430fr5969 -Wall -Werror=implicit-function-declaration --short-enums -Os -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -fno-inline -fno-common -I../../../../Library/include -g -c
+CFLAGS =  -ffunction-sections -fdata-sections -funit-at-a-time -mhwmult=f5series -mmcu=msp430fr5969 -Wall -Werror=implicit-function-declaration --short-enums -Os -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -fno-inline -fno-common -I../../../../Library/include -g -c
 export PLATFORM
 LINKER_OPT = -L../../../../Library/libs -g --gc-sections --relax -T ../../../../Build/platforms/msp430fr5969.ld.out -lcmsp430x -L$(LIBGCCDIR) -lgcc
 # cpp -P msp430fr5969.ld -I../../Build/platforms > msp430fr5969.ld.out

--- a/Applications/util/Makefile.msp430x
+++ b/Applications/util/Makefile.msp430x
@@ -1,11 +1,12 @@
 PLATFORM = msp430x
 CC = msp430-elf-gcc
 ASM = msp430-elf-as
-AR = msp430-elf-ar
-LINKER = msp430-elf-ld
-CFLAGS = -ffunction-sections -fdata-sections -funit-at-a-time -mhwmult=auto -mmcu=msp430fr5969 -Wall -Werror=implicit-function-declaration --short-enums -Os -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -fno-inline -fno-common -I../../Library/include -g -c
+AR = msp430-elf-ar  
+LINKER = msp430-elf-ld 
+
+CFLAGS =  -ffunction-sections -fdata-sections -funit-at-a-time -mhwmult=f5series -mmcu=msp430fr5969 -Wall -Werror=implicit-function-declaration --short-enums -Os -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -fno-inline -fno-common -I../../Library/include -g -c
 export PLATFORM
-LINKER_OPT = -L../../Library/libs -g --gc-sections --relax -T ../../Build/platforms/msp430fr5969.ld.out -lcmsp430x -L$(LIBGCCDIR) -lgcc
+LINKER_OPT = --undefined __mspabi_mpyul_f5hw -lmul_f5 -L../../Library/libs -g -gc-sections -relax -T ../../Build/platforms/msp430fr5969.ld.out -lcmsp430x -L$(LIBGCCDIR) -lgcc
 LIBGCCDIR = $(dir $(shell $(CC) -print-libgcc-file-name))
 CRT0 = ../../Library/libs/crt0_msp430x.o
 CRT0NS = ../../Library/libs/crt0nostdio_msp430x.o

--- a/Build/platforms/msp430fr5969.mk
+++ b/Build/platforms/msp430fr5969.mk
@@ -8,7 +8,7 @@ A = a
 TARGETCC = msp430-elf-gcc
 TARGETCPP = msp430-elf-cpp -nostdinc -undef -P
 TARGETAS = msp430-elf-as
-TARGETAR = msp430-elf-ar
+TARGETAR = msp430-elf-ar 
 TARGETLD = msp430-elf-ld
 TARGETOBJCOPY = msp430-elf-objcopy
 
@@ -17,7 +17,7 @@ targetgcc.cflags += \
 	-ffunction-sections \
 	-fdata-sections \
 	-funit-at-a-time \
-	-mhwmult=auto \
+	-mhwmult=f5series \
 	-mmcu=msp430fr5969
 
 target-exe.ldflags += \

--- a/Kernel/cpu-msp430x/rules.mk
+++ b/Kernel/cpu-msp430x/rules.mk
@@ -1,5 +1,5 @@
 export CROSS_CC = msp430-elf-gcc
-export CROSS_CCOPTS = -ffunction-sections -fdata-sections -funit-at-a-time -mhwmult=auto -mmcu=msp430fr5969 -Wall -Werror=implicit-function-declaration --short-enums -Os -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -fno-inline -fno-common -g -c -I. -I include -I cpu-$(CPU) -I platform-$(TARGET)
+export CROSS_CCOPTS = -ffunction-sections -fdata-sections -funit-at-a-time -mhwmult=f5series -mmcu=msp430fr5969 -Wall -Werror=implicit-function-declaration --short-enums -Os -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -fno-inline -fno-common -g -c -I. -I include -I cpu-$(CPU) -I platform-$(TARGET)
 export CROSS_ASOPTS = -c
 export ASOPTS = $(CROSS_ASOPTS)
 #TARGETCPP = msp430-elf-cpp -nostdinc -undef -P
@@ -20,7 +20,7 @@ targetgcc.cflags += \
 	-ffunction-sections \
 	-fdata-sections \
 	-funit-at-a-time \
-	-mhwmult=auto \
+	-mhwmult=f5series \
 	-mmcu=msp430fr5969
 
 target-exe.ldflags += \

--- a/Kernel/platform-msp430fr5969/Makefile
+++ b/Kernel/platform-msp430fr5969/Makefile
@@ -11,9 +11,7 @@ DOBJS = $(DSRCS:.c=$(BINEXT))
 CDOBJS = $(CDSRCS:.c=$(BINEXT))
 OBJS  = $(COBJS) $(AOBJS) $(DOBJS) $(CDOBJS)
 
-CROSS_CCOPTS = -ffunction-sections -fdata-sections -funit-at-a-time -mhwmult=auto -mmcu=msp430fr5969 -Wall -Werror=implicit-function-declaration --short-enums -Os -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -fno-inline -fno-common -g -c -I. -I ../include -I ../cpu-$(CPU) -I../dev/
-
-
+CROSS_CCOPTS = -ffunction-sections -fdata-sections -funit-at-a-time -mhwmult=f5series -mmcu=msp430fr5969 -Wall -Werror=implicit-function-declaration --short-enums -Os -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -fno-inline -fno-common -g -c -I. -I ../include -I ../cpu-$(CPU) -I../dev/
 CROSS_ASOPTS += -I..
 CROSS_ASOPTS += -g -c
 
@@ -52,7 +50,7 @@ msp430fr5969.ld.script: msp430fr5969.ld
 	cpp -P msp430fr5969.ld -I../../Build/platforms > msp430fr5969.ld.script
 
 image: msp430fr5969.ld.script
-	$(CROSS_LD) -s --relax -g -o ../fuzix.bin -Map=../fuzix.map --script=msp430fr5969.ld.script \
+	$(CROSS_LD)  --verbose --undefined __mspabi_mpyul_f5hw -lmul_f5 -s --relax -g -o ../fuzix.bin -Map=../fuzix.map --script=msp430fr5969.ld.script \
 	--start-group \
 	crt0.o main_discard.o tricks.o main.o lowlevel-msp430x.o devices.o devtty.o \
 	libc.o ../dev/blkdev.o ../dev/devsd.o devsdspi.o devsdspi_discard.o devices_discard.o ../dev/devsd_discard.o devtty_discard.o ../dev/mbr.o \

--- a/Library/libs/Makefile.msp430x
+++ b/Library/libs/Makefile.msp430x
@@ -1,9 +1,9 @@
 CC = msp430-elf-gcc
 ASM = msp430-elf-as
-AR = msp430-elf-ar
+AR = msp430-elf-ar 
 PLATFORM = msp430x
 export PLATFORM
-CC_OPT = -c -Os -I../include -I../include/$(PLATFORM)
+CC_OPT = -mhwmult=f5series -c -Os -I../include -I../include/$(PLATFORM) -mtiny-printf
 # for stuff that gives gcc nightmares
 CC_NOOPT = $(CC_OPT)
 ASM_OPT = -o
@@ -92,7 +92,7 @@ syscall.l: fuzix$(PLATFORM)/syslib.l
 
 syslib$(PLATFORM).lib: syscall.l libc.l
 	cat libc.l syscall.l >syslib.l
-	$(AR) rc syslib$(PLATFORM).lib $$(cat syslib.l)
+	$(AR) rc syslib$(PLATFORM).lib $$(cat syslib.l) 
 	ln -sf syslib$(PLATFORM).lib libc$(PLATFORM).a
 
 fuzix$(PLATFORM)/syslib.l: ../tools/syscall_$(PLATFORM)
@@ -109,15 +109,15 @@ liberror.txt: ../tools/liberror
 	make -C .. tools/liberror
 
 curses$(PLATFORM).lib: $(OBJ_CURS)
-	$(AR) rc curses$(PLATFORM).lib $(OBJ_CURS)
+	$(AR) rc curses$(PLATFORM).lib $(OBJ_CURS) 
 	ln -sf curses$(PLATFORM).lib libcurses$(PLATFORM).a
 
 termcap$(PLATFORM).lib: $(OBJ_CT)
-	$(AR) rc termcap$(PLATFORM).lib $(OBJ_CT)
+	$(AR) rc termcap$(PLATFORM).lib $(OBJ_CT)  
 	ln -sf termcap$(PLATFORM).lib libtermcap$(PLATFORM).a
 
 m$(PLATFORM).lib: $(OBJ_LM)
-	$(AR) rc m$(PLATFORM).lib $(OBJ_LM)
+	$(AR) rc m$(PLATFORM).lib $(OBJ_LM)  
 	ln -sf m$(PLATFORM).lib libm$(PLATFORM).a
 
 $(OBJ_ASM):%.o: %.s


### PR DESCRIPTION
Maki,

Here's the pull request for the work I've done to get FUZIX for msp430fr5969 to work with the newest TI gcc (9.2.0).

There's still data shuffling to be done to make the kernel compile, but the major hurdles seem to be over.

There is a whole new linker (.ld) file to be looked at, we should probably review that.

-Crawford